### PR TITLE
Move settings to the customFields in docusaurus.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ module.exports = {
     'docusaurus-plugin-yandex-metrica'
   ],
   themeConfig: {
-    ym: {
-      counterID: '86645179',
-    },
+    customFields: {
+      ym: {
+        counterID: '86645179',
+      },
+    }
   },
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-yandex-metrica",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Yandex.Metrica plugin for Docusaurus v2.",
   "main": "src/index.js",
   "publishConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,11 @@ const path = require('path');
 module.exports = function (context) {
   const {siteConfig} = context;
   const {themeConfig} = siteConfig;
-  const {ym} = themeConfig || {};
+  const {ym} = themeConfig.customFields || {};
 
   if (!ym) {
     throw new Error(
-      `You need to specify "ym" object in "themeConfig" with "counterID" field in it to use docusaurus-plugin-yandex-metrica.`,
+      `You need to specify "ym" object in "themeConfig.customFields" with "counterID" field in it to use docusaurus-plugin-yandex-metrica.`,
     );
   }
 
@@ -15,7 +15,7 @@ module.exports = function (context) {
 
   if (!counterID) {
     throw new Error(
-      'You specified the "ym" object in "themeConfig" but the "counterID" field was missing. ' +
+      'You specified the "ym" object in "themeConfig.customFields" but the "counterID" field was missing. ' +
         'Please ensure this is not a mistake.',
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,19 @@ const path = require('path');
 
 module.exports = function (context) {
   const {siteConfig} = context;
-  const {themeConfig} = siteConfig;
-  const {ym} = themeConfig.customFields || {};
+  const {customFields} = siteConfig;
+
+  if(!customFields) {
+    throw new Error(
+      `You need to specify "customFields" with "ym" object in "themeConfig" with "counterID" field in it to use docusaurus-plugin-yandex-metrica.`,
+    );
+  }
+
+  const {ym} = customFields || {}
 
   if (!ym) {
     throw new Error(
-      `You need to specify "ym" object in "themeConfig.customFields" with "counterID" field in it to use docusaurus-plugin-yandex-metrica.`,
+      `You need to specify "ym" object in "customFields" with "counterID" field in it to use docusaurus-plugin-yandex-metrica.`,
     );
   }
 
@@ -15,7 +22,7 @@ module.exports = function (context) {
 
   if (!counterID) {
     throw new Error(
-      'You specified the "ym" object in "themeConfig.customFields" but the "counterID" field was missing. ' +
+      'You specified the "ym" object in "customFields" but the "counterID" field was missing. ' +
         'Please ensure this is not a mistake.',
     );
   }

--- a/src/ym.js
+++ b/src/ym.js
@@ -8,9 +8,11 @@ export default (function () {
 
   const {
     themeConfig: {
-      ym: {counterID},
-    },
-  } = siteConfig;
+      customFields: {
+          ym: {counterID},
+        },
+      }
+    } = siteConfig;
 
   return {
     onRouteUpdate({location}) {


### PR DESCRIPTION
Hi @sgromkov.

I suggest moving the plugin settings to customFields, according to the [documentation](https://docusaurus.io/docs/next/api/docusaurus-config#customfields).

There are **problems with Typescript** because themeConfig has strictly described types in `import('@docusaurus/preset-classic').ThemeConfig`. Example of a linter message:

> Type '{ title: string; tagline: string; url: string; baseUrl: string; onBrokenLinks: "throw"; onBrokenMarkdownLinks: "warn"; favicon: string; plugins: string[]; presets: [string, Options][]; themeConfig: ThemeConfig; i18n: { ...; }; ym: { ...; }; }' is not assignable to type 'Config'.
  Object literal may only specify known properties, and 'ym' does not exist in type 'Config'